### PR TITLE
Remove long description from setup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
    - Fix building Python Wheels
+   - Removes long description from setup
 
 2020/03/02 (v0.7.0)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     keywords="nmap, portscanner, network, sysadmin",
     # Get more strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
     license='gpl-3.0.txt',
-    long_description=long_description,
+    long_description=description,
     name='netmap',
     packages=['nmap'],
     platforms=[


### PR DESCRIPTION
PyPi says something is wrong with the RST provided. Removing it.